### PR TITLE
Avoid bitshift of signed values.

### DIFF
--- a/Adafruit_INA3221.cpp
+++ b/Adafruit_INA3221.cpp
@@ -105,7 +105,7 @@ float Adafruit_INA3221::getShuntVoltage(uint8_t channel) {
 
   // Convert raw value to voltage
   float voltage =
-      (rawValue >> 3) * 40e-6; // Drop bottom 3 bits and multiply by 40uV
+      (float)rawValue * 5e-6; // Drop bottom 3 bits(divide by 8) and multiply by 40uV 
 
   return voltage;
 }

--- a/Adafruit_INA3221.cpp
+++ b/Adafruit_INA3221.cpp
@@ -105,7 +105,7 @@ float Adafruit_INA3221::getShuntVoltage(uint8_t channel) {
 
   // Convert raw value to voltage
   float voltage =
-      (float)rawValue * 5e-6; // Drop bottom 3 bits(divide by 8) and multiply by 40uV 
+      rawValue * 5.0e-6; // Drop bottom 3 bits(divide by 8) and multiply by 40uV
 
   return voltage;
 }


### PR DESCRIPTION
Bitshift to right of negative values is by definition undefined behaviour (compiler dependent). So better avoid it. 
The INA3221 sensor supports both negative and positive shunt voltage values.

